### PR TITLE
Configure URL from system env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,8 @@ use Mix.Config
 #
 #     import_config "#{Mix.env()}.exs"
 
-config :ex_watson_translator, url: "https://gateway.watsonplatform.net/language-translator/api"
 config :ex_watson_translator, version: System.get_env("VERSION") || "2018-05-01"
 config :ex_watson_translator, api_key: System.get_env("APIKEY")
+
+config :ex_watson_translator,
+  url: System.get_env("URL") || "https://gateway.watsonplatform.net/language-translator/api"

--- a/lib/translator_remote_api.ex
+++ b/lib/translator_remote_api.ex
@@ -77,8 +77,8 @@ defmodule TranslatorRemoteAPI do
 
         @url
         |> String.replace("translate?", "documents?")
-        |> HTTPoison.post({:multipart, body} , header)
-      end
+        |> HTTPoison.post({:multipart, body}, header)
+    end
   end
 
   defp build_body(data) when is_list(data) do
@@ -86,7 +86,7 @@ defmodule TranslatorRemoteAPI do
     {:ok, file_binary} = File.read(file_path)
 
     if byte_size(file_binary) < Formart.size_limit() do
-     :proplists.delete(:header, data)
+      :proplists.delete(:header, data)
     else
       {:error, "Maximum file size: 20 MB"}
     end

--- a/test/translator_remote_api_test.exs
+++ b/test/translator_remote_api_test.exs
@@ -109,8 +109,7 @@ defmodule TranslatorRemoteAPITest do
 
       document_id = get_available_status(list_of_documents)
 
-      assert {:ok, %{status_code: 200, body: body}} =
-               TranslatorRemoteAPI.translated(document_id)
+      assert {:ok, %{status_code: 200, body: body}} = TranslatorRemoteAPI.translated(document_id)
 
       assert is_binary(body)
       assert bit_size(body) > 0
@@ -143,10 +142,11 @@ defmodule TranslatorRemoteAPITest do
     list_of_documents
     |> Enum.find(fn map -> map["status"] == "available" end)
     |> Map.get("document_id")
-    |> case  do
+    |> case do
       "" ->
         Process.sleep(1000)
         get_available_status(list_of_documents)
+
       document_id ->
         document_id
     end


### PR DESCRIPTION
Watson API URL may be different for each API key. The URL should be made configurable, similarly to the API key.